### PR TITLE
[HOLD] Update to pull Email from Google.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ class AuthGoogleXoPlugin {
     xo.registerPassportStrategy(new Strategy(this._conf, async (accessToken, refreshToken, profile, done) => {
       try {
         console.log(profile)
-        done(null, await xo.registerUser('google', profile.displayName))
+        done(null, await xo.registerUser('google', profile.emails[0].value))
       } catch (error) {
         done(error.message)
       }


### PR DESCRIPTION
Using the same API Strategy, this changes the call from profile.displayName to profile.emails[0].value, which pulls the first email listed(usually the primary @gmail.com or apps domain) and registers it using said name.

Refer to ticket #1
