### PR TITLE
Modified the scope to use Google profile and email scope instead of the Google Plus scope

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ class AuthGoogleXoPlugin {
   configure (conf) {
     this._conf = {
       ...conf,
-      scope: 'https://www.googleapis.com/auth/plus.login'
+      scope: 'email profile'
     }
   }
 
@@ -40,7 +40,7 @@ class AuthGoogleXoPlugin {
     xo.registerPassportStrategy(new Strategy(this._conf, async (accessToken, refreshToken, profile, done) => {
       try {
         console.log(profile)
-        done(null, await xo.registerUser('google', profile.displayName))
+        done(null, await xo.registerUser('google', profile.emails[0].value))
       } catch (error) {
         done(error.message)
       }


### PR DESCRIPTION
Check this for reference :
https://developers.google.com/+/web/api/rest/oauth
In some case, the user won't have a Google Plus profile and the
profile.displayName will be empty, which is not really nice if you need
to do ACL or remove access to a user. Using the email seems more
appropriate since a user can change it's display name, and by doing so,
it will create a new XO account.